### PR TITLE
Make the library a bit more flexible internally

### DIFF
--- a/Web/Heroku.hs
+++ b/Web/Heroku.hs
@@ -7,41 +7,4 @@ import System.Environment
 import Network.URI
 import Data.Text
 import Prelude
-
--- | read the DATABASE_URL environment variable
--- and return an alist of connection parameters with the following keys:
--- user, password, host, port, dbname
---
--- warning: just calls error if it can't parse correctly
-dbConnParams :: IO [(Text, Text)]
-dbConnParams = getEnv "DATABASE_URL" >>= return . parseDatabaseUrl
-
-parseDatabaseUrl :: String -> [(Text, Text)]
-parseDatabaseUrl durl =
-  let muri = parseAbsoluteURI durl
-      (auth, path) = case muri of
-                      Nothing ->  error "couldn't parse absolute uri"
-                      Just uri -> if uriScheme uri /= "postgres:"
-                                    then schemeError uri
-                                    else case uriAuthority uri of
-                                           Nothing   -> invalid
-                                           Just a -> (a, uriPath uri)
-      (user,password) = userAndPassword auth
-  in     [
-          (pack "user",     user)
-          -- tail not safe, but should be there on Heroku
-         ,(pack "password", Data.Text.tail password)
-         ,(pack "host",     pack $ uriRegName auth)
-         -- Heroku should use default port
-         -- ,(pack "port",     pack $ uriPort auth)
-         -- tail not safe but path should always be there
-         ,(pack "dbname",   pack $ Prelude.tail $ path)
-         ]
-  where
-    -- init is not safe, but should be there on Heroku
-    userAndPassword :: URIAuth -> (Text, Text)
-    userAndPassword = (breakOn $ pack ":") . pack . Prelude.init . uriUserInfo
-
-    schemeError uri = error $ "was expecting a postgres scheme, not: " ++ (uriScheme uri) ++ "\n" ++ (show uri)
-    -- should be an error 
-    invalid = error "could not parse heroku DATABASE_URL"
+import Web.Heroku.Postgres (dbConnParams, parseDatabaseUrl)

--- a/Web/Heroku/Internal.hs
+++ b/Web/Heroku/Internal.hs
@@ -1,0 +1,47 @@
+module Web.Heroku.Internal ( 
+    dbConnParams' 
+  , parseDatabaseUrl'
+  ) where
+
+import System.Environment
+import Network.URI
+import Data.Text
+import Prelude
+
+-- | read the DATABASE_URL environment variable
+-- and return an alist of connection parameters with the following keys:
+-- user, password, host, port, dbname
+--
+-- warning: just calls error if it can't parse correctly
+dbConnParams' :: String -> (String -> [(Text, Text)]) -> IO [(Text, Text)]
+dbConnParams' envVar parse = getEnv envVar >>= return . parse
+
+parseDatabaseUrl' :: String -> String -> [(Text, Text)]
+parseDatabaseUrl' scheme durl =
+  let muri = parseAbsoluteURI durl
+      (auth, path) = case muri of
+                      Nothing ->  error "couldn't parse absolute uri"
+                      Just uri -> if uriScheme uri /= scheme
+                                    then schemeError uri
+                                    else case uriAuthority uri of
+                                           Nothing   -> invalid
+                                           Just a -> (a, uriPath uri)
+      (user,password) = userAndPassword auth
+  in     [
+          (pack "user",     user)
+          -- tail not safe, but should be there on Heroku
+         ,(pack "password", Data.Text.tail password)
+         ,(pack "host",     pack $ uriRegName auth)
+         -- Heroku should use default port
+         -- ,(pack "port",     pack $ uriPort auth)
+         -- tail not safe but path should always be there
+         ,(pack "dbname",   pack $ Prelude.tail $ path)
+         ]
+  where
+    -- init is not safe, but should be there on Heroku
+    userAndPassword :: URIAuth -> (Text, Text)
+    userAndPassword = (breakOn $ pack ":") . pack . Prelude.init . uriUserInfo
+
+    schemeError uri = error $ "was expecting a postgres scheme, not: " ++ (uriScheme uri) ++ "\n" ++ (show uri)
+    -- should be an error 
+    invalid = error "could not parse heroku DATABASE_URL"

--- a/Web/Heroku/Postgres.hs
+++ b/Web/Heroku/Postgres.hs
@@ -1,0 +1,13 @@
+module Web.Heroku.Postgres ( 
+    dbConnParams 
+  , parseDatabaseUrl
+  ) where
+
+import Data.Text
+import Web.Heroku.Internal (dbConnParams', parseDatabaseUrl')
+
+dbConnParams :: IO [(Text, Text)]
+dbConnParams = dbConnParams' "DATABASE_URL" parseDatabaseUrl
+
+parseDatabaseUrl :: String -> [(Text, Text)]
+parseDatabaseUrl = parseDatabaseUrl' "postgres:"

--- a/heroku.cabal
+++ b/heroku.cabal
@@ -14,7 +14,8 @@ Cabal-version:       >=1.2
 
 
 Library
-  Exposed-modules:     Web.Heroku
+  Exposed-modules: Web.Heroku
+                 , Web.Heroku.Postgres
   
   Build-depends: base >= 4 && < 5
                , text


### PR DESCRIPTION
I've refactored the library to allow it to search for different environment variables and database URI schemes. For example, I'm using a [MongoHQ](https://devcenter.heroku.com/articles/mongohq) database where the environment variable is called `"MONGOHQ_URL"` and the database URL starts with `mongo:`.
