### PR TITLE
Parse Port from DATABASE_URL

### DIFF
--- a/Web/Heroku/Internal.hs
+++ b/Web/Heroku/Internal.hs
@@ -32,8 +32,7 @@ parseDatabaseUrl' scheme durl =
           -- tail not safe, but should be there on Heroku
          ,(pack "password", Data.Text.tail password)
          ,(pack "host",     pack $ uriRegName auth)
-         -- Heroku should use default port
-         -- ,(pack "port",     pack $ uriPort auth)
+         ,(pack "port",     pack $ uriPort auth)
          -- tail not safe but path should always be there
          ,(pack "dbname",   pack $ Prelude.tail $ path)
          ]

--- a/test.hs
+++ b/test.hs
@@ -3,4 +3,4 @@ module Main where
 import Web.Heroku
 
 main = print $ show $
-  parseDatabaseUrl "postgres://db:pass@ec2-1-1-1-1.compute-1.amazonaws.com/db"
+  parseDatabaseUrl "postgres://db:pass@ec2-1-1-1-1.compute-1.amazonaws.com:1234/db"


### PR DESCRIPTION
Heroku Postgres uses the default port for its default database, but
Heroku production databases do not use the default port.

As specified in the note here:
https://devcenter.heroku.com/articles/upgrade-heroku-postgres-with-pgbackups#promote-new-database

> Please take care to note that the port number for your database may
> change during this process. You should ensure that the port is parsed
> correctly from the URL.
