### PR TITLE
Depend on network-uri instead of network

### DIFF
--- a/heroku.cabal
+++ b/heroku.cabal
@@ -22,7 +22,7 @@ Library
   
   Build-depends: base >= 4 && < 5
                , text
-               , network
+               , network-uri
 
 Test-Suite test
   Type:                 exitcode-stdio-1.0


### PR DESCRIPTION
The Network.URI module was split into separate package.

This fixes the build failure.
