### PR TITLE
Remove unused imports

### DIFF
--- a/Web/Heroku.hs
+++ b/Web/Heroku.hs
@@ -3,8 +3,4 @@ module Web.Heroku (
   , parseDatabaseUrl
   ) where
 
-import System.Environment
-import Network.URI
-import Data.Text
-import Prelude
 import Web.Heroku.Postgres (dbConnParams, parseDatabaseUrl)


### PR DESCRIPTION
I noticed that there were some imports in `Heroku.hs` that may have been left over from some refactoring. These imports are not being used in the file and compiling with `-Wall` produces warnings about them.