### PR TITLE
Add helper for RabbitMQ Bigwig

### DIFF
--- a/Web/Heroku/RabbitMQ.hs
+++ b/Web/Heroku/RabbitMQ.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE RecordWildCards #-}
+module Web.Heroku.RabbitMQ 
+  ( module Network.AMQP
+  , AmqpSettings(..)
+  , amqpConnSettings
+  , parseAmqpUrl
+  , openAmqpConnection
+  ) where
+
+import Control.Monad
+import Data.List.Split
+import Data.Text
+import Network.AMQP
+import System.Environment
+
+data AmqpSettings = AmqpSettings
+    { amqpHostName    :: String
+    , amqpVirtualHost :: String
+    , amqpUser        :: String
+    , amqpPass        :: String
+    , amqpPort        :: Int 
+    } deriving (Show, Eq)
+
+amqpConnSettings :: IO AmqpSettings
+amqpConnSettings = liftM parseAmqpUrl (getEnv "RABBITMQ_BIGWIG_URL")
+
+parseAmqpUrl :: String -> AmqpSettings
+parseAmqpUrl = parse . splitOneOf "@:/" . trimProtocol
+  where
+    parse :: [String] -> AmqpSettings
+    parse [ user
+          , pass
+          , host
+          , port
+          , vhst 
+          ] = AmqpSettings host vhst user pass (read port)
+    parse _ = error "Unexpected environment variable format."
+
+    trimProtocol :: String -> String
+    trimProtocol ('a':'m':'q':'p':':':'/':'/':rest) = rest
+    trimProtocol str = str
+
+openAmqpConnection :: IO Connection
+openAmqpConnection = 
+     amqpConnSettings >>= \AmqpSettings{..} -> 
+        openConnection' 
+            amqpHostName 
+            (fromIntegral amqpPort)
+            (pack amqpVirtualHost)
+            (pack amqpUser) 
+            (pack amqpPass)
+

--- a/Web/Heroku/RabbitMQ.hs
+++ b/Web/Heroku/RabbitMQ.hs
@@ -10,9 +10,9 @@ import System.Environment
 
 data AmqpSettings = AmqpSettings
     { amqpHostName    :: String
-    , amqpVirtualHost :: String
-    , amqpUser        :: String
-    , amqpPass        :: String
+    , amqpVirtualHost :: Text
+    , amqpUser        :: Text
+    , amqpPass        :: Text
     , amqpPort        :: Int 
     } deriving (Show, Eq)
 
@@ -28,7 +28,7 @@ parseAmqpUrl = parse . pieces "" [] . trimProtocol
           , host
           , port
           , vhst 
-          ] = AmqpSettings host vhst user pass (read port)
+          ] = AmqpSettings host (pack vhst) (pack user) (pack pass) (read port)
     parse _ = error "Unexpected environment variable format."
 
     trimProtocol :: String -> String

--- a/Web/Heroku/RabbitMQ.hs
+++ b/Web/Heroku/RabbitMQ.hs
@@ -9,11 +9,11 @@ import Data.Text ( Text, pack )
 import System.Environment
 
 data AmqpSettings = AmqpSettings
-    { amqpHostName    :: String
-    , amqpVirtualHost :: Text
-    , amqpUser        :: Text
-    , amqpPass        :: Text
-    , amqpPort        :: Int 
+    { amqpHostName    :: !String
+    , amqpVirtualHost :: !Text
+    , amqpUser        :: !Text
+    , amqpPass        :: !Text
+    , amqpPort        :: !Int 
     } deriving (Show, Eq)
 
 amqpConnSettings :: IO AmqpSettings

--- a/heroku.cabal
+++ b/heroku.cabal
@@ -24,8 +24,6 @@ Library
   Build-depends: base >= 4 && < 5
                , text
                , network-uri
-               , split
-               , amqp
 
 Test-Suite test
   Type:                 exitcode-stdio-1.0
@@ -34,5 +32,3 @@ Test-Suite test
                , text
                , network-uri
                , hspec
-               , amqp
-               , split

--- a/heroku.cabal
+++ b/heroku.cabal
@@ -17,12 +17,15 @@ Library
   Exposed-modules: Web.Heroku
                  , Web.Heroku.Postgres
                  , Web.Heroku.MongoDB
+                 , Web.Heroku.RabbitMQ
 
   Other-modules: Web.Heroku.Internal
   
   Build-depends: base >= 4 && < 5
                , text
                , network-uri
+               , split
+               , amqp
 
 Test-Suite test
   Type:                 exitcode-stdio-1.0
@@ -31,3 +34,5 @@ Test-Suite test
                , text
                , network-uri
                , hspec
+               , amqp
+               , split

--- a/test.hs
+++ b/test.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Web.Heroku
 import Test.Hspec
+import Web.Heroku
+import Web.Heroku.RabbitMQ
 
 main :: IO ()
-main = hspec $
+main = hspec $ do
   describe "parseDatabaseUrl" $
     it "extracts individual items" $
       parseDatabaseUrl "postgres://db:pass@ec2-1-1-1-1.compute-1.amazonaws.com:1234/db" `shouldBe`
@@ -15,3 +16,14 @@ main = hspec $
         , ("port","1234")
         , ("dbname","db")
         ]
+  describe "parseAmqpUrl" $
+    it "extracts amqp connection settings" $
+      parseAmqpUrl "amqp://ebA3ec8f:54EnktG1MgGvwPftC4y7BfZIQTYqrtvD@massive-scale-12.bigwig.lshift.net:10210/Uao4j39t8qD_" `shouldBe`
+        AmqpSettings
+            { amqpHostName    = "massive-scale-12.bigwig.lshift.net"
+            , amqpVirtualHost = "Uao4j39t8qD_"
+            , amqpUser        = "ebA3ec8f"
+            , amqpPass        = "54EnktG1MgGvwPftC4y7BfZIQTYqrtvD"
+            , amqpPort        = 10210
+            }
+


### PR DESCRIPTION
This module reads and parses configuration variables for Heroku's RabbitMQ Bigwig add-on and re-exports the API from Network.AMQP. It also exposes an openAmqpConnection call which simply reads and parses the relevant variable (RABBITMQ_BIGWIG_URL) and subsequently calls openConnection' to connect to the RabbitMQ service. Perhaps this should be put in a separate package, but I find it quite convenient to have these helpers under a common namespace (Web.Heroku.X). 
